### PR TITLE
We need directory >= 1.2.6.0 for usage of `isSymbolicLink'

### DIFF
--- a/MissingH.cabal
+++ b/MissingH.cabal
@@ -90,7 +90,7 @@ Library
                filepath,
                hslogger
  If flag(splitBase)
-   Build-Depends: base >= 4, base < 5, directory, random, process, old-time,
+   Build-Depends: base >= 4, base < 5, directory >= 1.2.6.0, random, process, old-time,
                              containers, old-locale, array, time
  Else
    Build-Depends: base < 3


### PR DESCRIPTION
This makes the package easier to build on older GHCs

I published a revision (https://hackage.haskell.org/package/MissingH-1.4.0.0/revisions/) so a new release is not necessary.
