### PR TITLE
Fix GHC 7.4 build with older versions of directory, and add base lower bounds

### DIFF
--- a/MissingH.cabal
+++ b/MissingH.cabal
@@ -86,7 +86,7 @@ Library
                mtl, HUnit, regex-compat,
                filepath,
                hslogger,
-               base >= 4, base < 5, directory, random, process, old-time,
+               base >= 4.5, base < 5, directory, random, process, old-time,
                            containers, old-locale, array, time
  If ! os(windows)
    Build-Depends: unix
@@ -99,7 +99,7 @@ test-suite runtests
                errorcall-eq-instance,
                filepath,
                hslogger,
-               base >= 4, base < 5, directory, random, process, old-time,
+               base >= 4.5, base < 5, directory, random, process, old-time,
                          containers, old-locale, array, time
   If ! os(windows)
    Build-Depends: unix

--- a/MissingH.cabal
+++ b/MissingH.cabal
@@ -39,9 +39,6 @@ Stability: Beta
 Build-Type: Simple
 Cabal-Version: >=1.8
 
-Flag splitBase
-  description: Choose the new smaller, split-up base package.
-
 Library
  Hs-Source-Dirs: src
  Exposed-Modules:
@@ -88,12 +85,9 @@ Library
  Build-Depends: network, parsec, base,
                mtl, HUnit, regex-compat,
                filepath,
-               hslogger
- If flag(splitBase)
-   Build-Depends: base >= 4, base < 5, directory, random, process, old-time,
-                             containers, old-locale, array, time
- Else
-   Build-Depends: base < 3
+               hslogger,
+               base >= 4, base < 5, directory, random, process, old-time,
+                           containers, old-locale, array, time
  If ! os(windows)
    Build-Depends: unix
 
@@ -104,12 +98,9 @@ test-suite runtests
                mtl, HUnit, regex-compat,
                errorcall-eq-instance,
                filepath,
-               hslogger
-  If flag(splitBase)
-   Build-Depends: base >= 4, base < 5, directory, random, process, old-time,
-                             containers, old-locale, array, time
-  Else
-   Build-Depends: base < 3
+               hslogger,
+               base >= 4, base < 5, directory, random, process, old-time,
+                         containers, old-locale, array, time
   If ! os(windows)
    Build-Depends: unix
   Build-Depends: testpack, QuickCheck, HUnit


### PR DESCRIPTION
This is a fix for #34.

It turns out that Safe annotations were added in the most recent versions and that excludes GHC < 7.4. An alternative fix would be to CPP out the annotations on older GHCs. I can make that change if you prefer.



